### PR TITLE
Fixed unsafe negation in formatDate function

### DIFF
--- a/.vitepress/getPosts.js
+++ b/.vitepress/getPosts.js
@@ -26,7 +26,7 @@ exports.getPosts = function getPosts(asFeed = false) {
 }
 
 function formatDate(date) {
-  if (!date instanceof Date) {
+  if (!(date instanceof Date)) {
     date = new Date(date)
   }
   date.setUTCHours(12)


### PR DESCRIPTION
This pull request fixes an unsafe negation in the formatDate function in the getPosts file.

**Description of problem**

The current code looks like this and will always evaluate to false
```js
if (!date instanceof Date) // This line will always evaluate to false
    date = new Date(date)
```
**Example**
```js
let realDate = new Date()
let fakeDate = '2017-05-28'

!fakeDate instanceof Date // Outputs false
!realDate instanceof Date // Outputs false
!(fakeDate instanceof Date) // Outputs true
!(realDate instanceof Date) //Outputs false
```

**Solution**

The solution to this is to negate the entire expression instead of the left-hand operand
```js
if (!(date instanceof Date)) // This line will always evaluate to false
    date = new Date(date)
```