### PR TITLE
fix: navigating from index page to the new Vue 3 post

### DIFF
--- a/posts/vue-3-as-the-new-default.md
+++ b/posts/vue-3-as-the-new-default.md
@@ -8,7 +8,7 @@ twitter: '@youyuxi'
 
 TL;DR: Vue 3 will become the new default version on **Monday, February 7, 2022**!
 
-Make sure to read the [Potential Required Actions](#potential-required-actions) section to see if you need to make certain changes before the switch to avoid breakage.
+Make sure to read the [Potential Required Actions](/posts/vue-3-as-the-new-default.html#potential-required-actions) section to see if you need to make certain changes before the switch to avoid breakage.
 
 ---
 


### PR DESCRIPTION
Spotted this one when adding the new post to the [îles demo](https://the-vue-point-with-iles.netlify.app/) 😃 

Since the rendered markdown could be used in different pages, the easiest fix is to use the full path.

### Replication Steps

- Visit [the index page](https://blog.vuejs.org/)
- Click on __Potential Required Actions__
- Stays on the page (`https://blog.vuejs.org/#potential-required-actions`)