### PR TITLE
add prefers-color-scheme based dark mode

### DIFF
--- a/.vitepress/theme/Article.vue
+++ b/.vitepress/theme/Article.vue
@@ -20,7 +20,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
 </script>
 
 <template>
-  <article class="xl:divide-y xl:divide-gray-200">
+  <article class="xl:divide-y xl:divide-gray-200 dark:xl:divide-slate-200/5">
     <header class="pt-6 xl:pb-10 space-y-1 text-center">
       <Date :date="date" />
       <h1
@@ -28,7 +28,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           text-3xl
           leading-9
           font-extrabold
-          text-gray-900
+          text-gray-900 dark:text-white
           tracking-tight
           sm:text-4xl sm:leading-10
           md:text-5xl md:leading-14
@@ -42,7 +42,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
       class="
         divide-y
         xl:divide-y-0
-        divide-gray-200
+        divide-gray-200 dark:divide-slate-200/5
         xl:grid xl:grid-cols-4 xl:gap-x-10
         pb-16
         xl:pb-20
@@ -50,8 +50,8 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
       style="grid-template-rows: auto 1fr"
     >
       <Author />
-      <div class="divide-y divide-gray-200 xl:pb-0 xl:col-span-3 xl:row-span-2">
-        <Content class="prose max-w-none pt-10 pb-8" />
+      <div class="divide-y divide-gray-200 dark:divide-slate-200/5 xl:pb-0 xl:col-span-3 xl:row-span-2">
+        <Content class="prose dark:prose-invert max-w-none pt-10 pb-8" />
       </div>
 
       <footer
@@ -59,12 +59,12 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           text-sm
           font-medium
           leading-5
-          divide-y divide-gray-200
+          divide-y divide-gray-200 dark:divide-slate-200/5
           xl:col-start-1 xl:row-start-2
         "
       >
         <div v-if="nextPost" class="py-8">
-          <h2 class="text-xs tracking-wide uppercase text-gray-500">
+          <h2 class="text-xs tracking-wide uppercase text-gray-500 dark:text-white">
             Next Article
           </h2>
           <div class="link">
@@ -72,7 +72,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           </div>
         </div>
         <div v-if="prevPost" class="py-8">
-          <h2 class="text-xs tracking-wide uppercase text-gray-500">
+          <h2 class="text-xs tracking-wide uppercase text-gray-500 dark:text-white">
             Previous Article
           </h2>
           <div class="link">

--- a/.vitepress/theme/Author.vue
+++ b/.vitepress/theme/Author.vue
@@ -5,7 +5,7 @@ const { frontmatter } = useData()
 </script>
 
 <template>
-  <dl class="pt-6 pb-10 xl:pt-11 xl:border-b xl:border-gray-200">
+  <dl class="pt-6 pb-10 xl:pt-11 xl:border-b xl:border-gray-200 dark:xl:border-slate-200/5">
     <dt class="sr-only">Authors</dt>
     <dd>
       <ul
@@ -27,7 +27,7 @@ const { frontmatter } = useData()
           />
           <dl class="text-sm font-medium leading-5 whitespace-nowrap">
             <dt class="sr-only">Name</dt>
-            <dd class="text-gray-900">{{ frontmatter.author }}</dd>
+            <dd class="text-gray-900 dark:text-white">{{ frontmatter.author }}</dd>
             <dt v-if="frontmatter.twitter" class="sr-only">Twitter</dt>
             <dd v-if="frontmatter.twitter">
               <a

--- a/.vitepress/theme/Date.vue
+++ b/.vitepress/theme/Date.vue
@@ -14,7 +14,7 @@ function getDateTime() {
 <template>
   <dl>
     <dt class="sr-only">Published on</dt>
-    <dd class="text-base leading-6 font-medium text-gray-500">
+    <dd class="text-base leading-6 font-medium text-gray-500 dark:text-gray-300">
       <time :datetime="getDateTime()">{{ date.string }}</time>
     </dd>
   </dl>

--- a/.vitepress/theme/Home.vue
+++ b/.vitepress/theme/Home.vue
@@ -4,14 +4,14 @@ import { data as posts } from '../posts.data'
 </script>
 
 <template>
-  <div class="divide-y divide-gray-200">
+  <div class="divide-y divide-gray-200 dark:divide-slate-200/5">
     <div class="pt-6 pb-8 space-y-2 md:space-y-5">
       <h1
         class="
           text-3xl
           leading-9
           font-extrabold
-          text-gray-900
+          text-gray-900 dark:text-white
           tracking-tight
           sm:text-4xl sm:leading-10
           md:text-6xl md:leading-14
@@ -19,9 +19,9 @@ import { data as posts } from '../posts.data'
       >
         {{ $frontmatter.title }}
       </h1>
-      <p class="text-lg leading-7 text-gray-500">{{ $frontmatter.subtext }}</p>
+      <p class="text-lg leading-7 text-gray-500 dark:text-white">{{ $frontmatter.subtext }}</p>
     </div>
-    <ul class="divide-y divide-gray-200">
+    <ul class="divide-y divide-gray-200 dark:divide-slate-200/5">
       <li class="py-12" v-for="{ title, href, date, excerpt } of posts">
         <article
           class="
@@ -33,11 +33,11 @@ import { data as posts } from '../posts.data'
           <div class="space-y-5 xl:col-span-3">
             <div class="space-y-6">
               <h2 class="text-2xl leading-8 font-bold tracking-tight">
-                <a class="text-gray-900" :href="href">{{ title }}</a>
+                <a class="text-gray-900 dark:text-white" :href="href">{{ title }}</a>
               </h2>
               <div
                 v-if="excerpt"
-                class="prose max-w-none text-gray-500"
+                class="prose dark:prose-invert max-w-none text-gray-500 dark:text-gray-300"
                 v-html="excerpt"
               ></div>
             </div>

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="antialiased">
+  <div class="antialiased dark:bg-slate-900">
     <div class="max-w-3xl mx-auto px-4 sm:px-6 xl:max-w-5xl xl:px-0">
       <nav class="flex justify-between items-center py-10 font-bold">
         <a class="text-xl" href="/" aria-label="The Vue Point">
@@ -9,21 +9,21 @@
             alt="logo"
             src="/logo.svg"
           />
-          <span v-if="!isIndex" class="hidden md:inline">The Vue Point</span>
+          <span v-if="!isIndex" class="hidden md:inline dark:text-white">The Vue Point</span>
         </a>
-        <div class="text-sm text-gray-500 leading-5">
+        <div class="text-sm text-gray-500 dark:text-white leading-5">
           <a
-            class="hover:text-gray-700"
+            class="hover:text-gray-700 dark:hover:text-gray-200"
             href="https://github.com/vuejs/blog"
             target="_blank"
             rel="noopener"
             ><span class="hidden sm:inline">GitHub </span>Source</a
           >
           <span class="mr-2 ml-2">·</span>
-          <a class="hover:text-gray-700" href="/feed.rss">RSS<span class="hidden sm:inline"> Feed</span></a>
+          <a class="hover:text-gray-700 dark:hover:text-gray-200" href="/feed.rss">RSS<span class="hidden sm:inline"> Feed</span></a>
           <span class="mr-2 ml-2">·</span>
           <a
-            class="hover:text-gray-700"
+            class="hover:text-gray-700 dark:hover:text-gray-200"
             href="https://vuejs.org"
             target="_blank"
             rel="noopener"


### PR DESCRIPTION
Dark mode user here 🙂 

This PR adds some CSS classes from Tailwind to create a nice-looking dark mode (highly inspired by Tailwind CSS blog and docs with the slate background).

## Home
![image](https://user-images.githubusercontent.com/9519976/152666754-6ade6192-a5b0-47aa-9c2a-061c6d1619e5.png)

## Article
![image](https://user-images.githubusercontent.com/9519976/152666758-19b783e3-a1b5-494b-9f24-43453bc85922.png)

![image](https://user-images.githubusercontent.com/9519976/152666778-980a8063-0981-4bef-9f55-85f33e3e8308.png)


## Code
![image](https://user-images.githubusercontent.com/9519976/152666765-b189892e-899a-485c-a9f7-86df3762d605.png)


