### PR TITLE
Add support for optional tags

### DIFF
--- a/.vitepress/theme/Archive.vue
+++ b/.vitepress/theme/Archive.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+    import Date from './Date.vue'
+    import { data as posts } from './posts.data.js'
+    import { useData, useRoute } from 'vitepress'
+    import { ref } from 'vue';
+
+    const { frontmatter } = useData()
+
+    const route = useRoute()
+    route.data.title = "Archive"
+    </script>
+
+        <template>
+
+          <div class="divide-y divide-gray-200">
+            <div class="pt-6 pb-8 space-y-2 md:space-y-5">
+              <h1 class="text-3xl leading-9 font-extrabold text-gray-900 tracking-tight sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+                Archive
+              </h1>
+              <p class="text-lg leading-7 text-gray-500">Shows all posts</p>
+            </div>
+            <ul class="divide-y divide-gray-200">
+              <li class="py-12" v-for="{ title, href, date, excerpt } of posts">
+                <article
+                  class="space-y-2 xl:grid xl:grid-cols-4 xl:space-y-0 xl:items-baseline"
+                >
+                  <Date :date="date" />
+                  <div class="space-y-5 xl:col-span-3">
+                    <div class="space-y-6">
+                      <h2 class="text-2xl leading-8 font-bold tracking-tight">
+                        <a class="text-gray-900" :href="href">{{ title }}</a>
+                      </h2>
+                      <div
+                        v-if="excerpt"
+                        class="prose max-w-none text-gray-500"
+                        v-html="excerpt"
+                      ></div>
+                    </div>
+                    <div class="text-base leading-6 font-medium">
+                      <a class="link" aria-label="read more" :href="href"
+                        >Read more →</a
+                      >
+                    </div>
+                  </div>
+                </article>
+              </li>
+
+            </ul>
+          </div>
+        </template>

--- a/.vitepress/theme/Article.vue
+++ b/.vitepress/theme/Article.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Date from './Date.vue'
 import Author from './Author.vue'
+import Tags from './Tags.vue'
 import { computed } from 'vue'
 import { useData, useRoute } from 'vitepress'
 import { data as posts } from './posts.data.js'
@@ -63,6 +64,12 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           xl:col-start-1 xl:row-start-2
         "
       >
+        <div class="py-8" v-if="data.tags">
+          <h2 class="text-xs tracking-wide uppercase text-gray-500">
+            Tags
+          </h2>
+          <Tags />
+        </div>
         <div v-if="nextPost" class="py-8">
           <h2 class="text-xs tracking-wide uppercase text-gray-500">
             Next Article

--- a/.vitepress/theme/Home.vue
+++ b/.vitepress/theme/Home.vue
@@ -16,25 +16,26 @@ const { frontmatter } = useData()
       </h1>
       <p class="text-lg leading-7 text-gray-500">{{ frontmatter.subtext }}</p>
     </div>
-    <ul class="divide-y divide-gray-200">
-      <li class="py-12" v-for="{ title, href, date, excerpt } of posts">
+
+    <ul class="divide-y divide-gray-200" v-for="(post, index) in posts">
+      <li class="py-12" v-if="index <= 4">
         <article
           class="space-y-2 xl:grid xl:grid-cols-4 xl:space-y-0 xl:items-baseline"
         >
-          <Date :date="date" />
+          <Date :date="post.date" />
           <div class="space-y-5 xl:col-span-3">
             <div class="space-y-6">
               <h2 class="text-2xl leading-8 font-bold tracking-tight">
-                <a class="text-gray-900" :href="href">{{ title }}</a>
+                <a class="text-gray-900" :href="post.href">{{ post.title }}</a>
               </h2>
               <div
-                v-if="excerpt"
+                v-if="post.excerpt"
                 class="prose max-w-none text-gray-500"
-                v-html="excerpt"
+                v-html="post.excerpt"
               ></div>
             </div>
             <div class="text-base leading-6 font-medium">
-              <a class="link" aria-label="read more" :href="href"
+              <a class="link" aria-label="read more" :href="post.href"
                 >Read more →</a
               >
             </div>
@@ -42,5 +43,9 @@ const { frontmatter } = useData()
         </article>
       </li>
     </ul>
+
+    <div class="space-y-2 xl:grid xl:grid-cols-4 xl:space-y-0 xl:items-baseline py-12 text-base leading-6 font-medium text-gray-500">
+      <a class="link" href="/archive">→ Go to Archive</a>
+    </div>
   </div>
 </template>

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -4,11 +4,13 @@ import { useRoute } from 'vitepress'
 import Home from './Home.vue'
 import Article from './Article.vue'
 import Tagged from './Tagged.vue'
+import Archive from './Archive.vue'
 import NotFound from './NotFound.vue'
 
 const route = useRoute()
 const isIndex = computed(() => route.path.replace(/index.html$/, '') === '/')
 const isTagged = computed(() => route.path.replace(/tags\/.+.html$/, '') === '/')
+const isArchive = computed(() => route.path.replace(/archive.html$/, '') === '/')
 const isNotFound = computed(() => route.component === NotFound)
 </script>
 
@@ -50,6 +52,7 @@ const isNotFound = computed(() => route.component === NotFound)
     </div>
     <main class="max-w-3xl mx-auto px-4 sm:px-6 xl:max-w-5xl xl:px-0">
       <Home v-if="isIndex" />
+      <Archive v-else-if="isArchive" />
       <Tagged v-else-if="isTagged" :path="route.path" />
       <NotFound v-else-if="isNotFound" />
       <Article v-else />

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -3,10 +3,12 @@ import { computed } from 'vue'
 import { useRoute } from 'vitepress'
 import Home from './Home.vue'
 import Article from './Article.vue'
+import Tagged from './Tagged.vue'
 import NotFound from './NotFound.vue'
 
 const route = useRoute()
 const isIndex = computed(() => route.path.replace(/index.html$/, '') === '/')
+const isTagged = computed(() => route.path.replace(/tags\/.+.html$/, '') === '/')
 const isNotFound = computed(() => route.component === NotFound)
 </script>
 
@@ -48,6 +50,7 @@ const isNotFound = computed(() => route.component === NotFound)
     </div>
     <main class="max-w-3xl mx-auto px-4 sm:px-6 xl:max-w-5xl xl:px-0">
       <Home v-if="isIndex" />
+      <Tagged v-else-if="isTagged" :path="route.path" />
       <NotFound v-else-if="isNotFound" />
       <Article v-else />
     </main>

--- a/.vitepress/theme/Tagged.vue
+++ b/.vitepress/theme/Tagged.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+    import Date from './Date.vue'
+    import { data as posts } from './posts.data.js'
+    import Tags from './Tags.vue'
+    import { useData, useRoute } from 'vitepress'
+    import { ref, toRefs, watch } from 'vue'
+
+    const route = useRoute()
+    const { frontmatter } = useData()
+
+    // Get path and parse it
+    const props = defineProps({
+        path: String
+    })
+    const { path } = toRefs(props)
+    const taggedPath = path?.value
+    const taggedSlug = taggedPath?.substring(taggedPath.lastIndexOf('/') +1).replace(/\.[^/.]+$/, "")
+
+    // Get tagged posts
+    var taggedPosts:any = [];
+    for (let post of posts) {
+        if (post.tags && post.tags.includes(taggedSlug)) { taggedPosts.push(post) }
+    }
+
+    // Update <title>
+    if (taggedPosts > 0) {
+        route.data.title = (taggedSlug || "")
+    }
+    </script>
+
+    <template>
+
+      <div class="divide-y divide-gray-200">
+        <div class="pt-6 pb-8 space-y-2 md:space-y-5">
+          <h1 class="text-3xl leading-9 font-extrabold text-gray-900 tracking-tight sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 capitalize">
+            {{ taggedSlug }}
+          </h1>
+          <p v-if="taggedPosts.length < 1">There's no posts tagged with '{{ taggedSlug }}'</p>
+          <p v-else class="text-lg leading-7 text-gray-500">Shows posts tagged with '{{ taggedSlug }}'</p>
+        </div>
+
+
+        <div v-for="(post,index) in taggedPosts">
+          <template v-if="index <= 4">
+            <ul>
+            <li class="py-12">
+            <article class="space-y-2 xl:grid xl:grid-cols-4 xl:space-y-0 xl:items-baseline">
+              <Date :date="post.date" />
+              <div class="space-y-5 xl:col-span-3">
+                <Tags />
+                <div class="space-y-6">
+                  <h2 class="text-2xl leading-8 font-bold tracking-tight">
+                    <a class="text-gray-900" :href="post.href">{{ post.title }}</a>
+                  </h2>
+                  <div
+                    v-if="post.excerpt"
+                    class="prose max-w-none text-gray-500"
+                    v-html="post.excerpt"
+                  ></div>
+                </div>
+                <div class="text-base leading-6 font-medium">
+                  <a class="link" aria-label="read more" :href="post.href"
+                    >Read more →</a
+                  >
+                </div>
+              </div>
+            </article>
+          </li>
+          </ul>
+        </template>
+        </div>
+
+      </div>
+    </template>

--- a/.vitepress/theme/Tagged.vue
+++ b/.vitepress/theme/Tagged.vue
@@ -19,11 +19,13 @@
     // Get tagged posts
     var taggedPosts:any = [];
     for (let post of posts) {
-        if (post.tags && post.tags.includes(taggedSlug)) { taggedPosts.push(post) }
+        if (post.tags && post.tags.includes(taggedSlug || "")) {
+            taggedPosts.push(post)
+        }
     }
 
     // Update <title>
-    if (taggedPosts > 0) {
+    if (taggedPosts.length > 0) {
         route.data.title = (taggedSlug || "")
     }
     </script>

--- a/.vitepress/theme/Tags.vue
+++ b/.vitepress/theme/Tags.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useData } from 'vitepress';
+const { frontmatter } = useData()
+</script>
+<template>
+    <ul>
+        <li class="md:inline tracking-wide capitalize text-g-900" v-for="(tag, key) in frontmatter.tags">
+            <a class="link" :href="'/tags/' + tag">{{ tag }}</a><span v-if="key != frontmatter.tags.length - 1">, </span>
+        </li>
+    </ul>
+</template>

--- a/.vitepress/theme/posts.data.ts
+++ b/.vitepress/theme/posts.data.ts
@@ -15,7 +15,7 @@ export interface Post {
     time: number
     string: string
   }
-  tags: object
+  tags: Array<string>
   excerpt: string | undefined
   data?: Record<string, any>
 }

--- a/.vitepress/theme/posts.data.ts
+++ b/.vitepress/theme/posts.data.ts
@@ -15,6 +15,7 @@ export interface Post {
     time: number
     string: string
   }
+  tags: object
   excerpt: string | undefined
   data?: Record<string, any>
 }
@@ -59,6 +60,7 @@ function getPost(file: string, postDir: string, asFeed = false): Post {
     title: data.title,
     href: `/posts/${file.replace(/\.md$/, '.html')}`,
     date: formatDate(data.date),
+    tags: data.tags,
     excerpt: excerpt && md.render(excerpt)
   }
   if (asFeed) {


### PR DESCRIPTION
Adds support for optional tags in frontmatter in the sidebar/footer of the post and makes them clickable.

Example by adding tags to this post's frontmatter:
```
---
title: Vue 2.7 "Naruto" Released
date: 2022-07-01
author: Evan You
gravatar: eca93da2c67aadafe35d477aa8f454b8
twitter: '@youyuxi'
tags: ["vue", "front-end"]
---

```

### Shows inline list of tags in sidebar
<img width="1128" alt="tags-in-sidebar" src="https://user-images.githubusercontent.com/10997469/188332401-5869cfc3-4bbf-4d3e-bb55-6cbfccf9fc2b.png">

---

### Clicking a tag, I get a list of posts that contains that tag.

<img width="1150" alt="tag-page" src="https://user-images.githubusercontent.com/10997469/188333071-74e8bccc-e719-4f86-95cf-55268bf8083b.png">
