### PR TITLE
Update vue-2-7-naruto.md

### DIFF
--- a/posts/vue-2-7-naruto.md
+++ b/posts/vue-2-7-naruto.md
@@ -76,10 +76,9 @@ In addition, the following features are explicitly **NOT** ported:
 
 ### Vue CLI / webpack
 
-1. Upgrade local `@vue/cli-xxx` dependencies the latest version in your major version range (if applicable):
+1. Upgrade local `@vue/cli-xxx` dependencies to the latest version (if applicable):
 
-   - `~4.5.18` for v4
-   - `~5.0.6` for v5
+   - `~5.0.8` for v5
 
 2. Upgrade `vue` to `^2.7.0`. You can also remove `vue-template-compiler` from the dependencies - it is no longer needed in 2.7.
 


### PR DESCRIPTION
cli-service v4 has unmet peer dependency of vue: ^3.  
cli-service v4 is therefore not compatible with vue2.7.  
cli-service v5 is compatible.