### PR TITLE
fix generated rss include zero width space

### DIFF
--- a/.vitepress/genFeed.ts
+++ b/.vitepress/genFeed.ts
@@ -35,7 +35,7 @@ export async function genFeed(config: SiteConfig) {
       id: `${baseUrl}${url}`,
       link: `${baseUrl}${url}`,
       description: excerpt,
-      content: html,
+      content: html?.replaceAll('&ZeroWidthSpace;', ''),
       author: [
         {
           name: frontmatter.author,


### PR DESCRIPTION
The generated rss contains `&ZeroWidthSpace;`, which will appear strangely in inoreader and feedly. This does not seem right.

![image](https://github.com/vuejs/blog/assets/24560368/07fc2ddc-6fd1-4f56-a997-09cca2816873)

Related vitepress issue: https://github.com/vuejs/vitepress/issues/3364