### PR TITLE
fix: export type

### DIFF
--- a/.vitepress/theme/posts.data.ts
+++ b/.vitepress/theme/posts.data.ts
@@ -1,6 +1,6 @@
 import { createContentLoader } from 'vitepress'
 
-interface Post {
+export interface Post {
   title: string
   url: string
   date: {


### PR DESCRIPTION
Got a import error message when open `./.vitepress/theme/Date.vue`, so i export `interface Post` from `./.vitepress/theme/posts.data.ts` for fix it.