### PR TITLE
chore: add preview script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vitepress --open",
     "build": "vitepress build",
-    "serve": "vitepress serve"
+    "serve": "vitepress serve",
+    "preview": "vitepress preview"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",


### PR DESCRIPTION
It's nice to have a preview script for local build preview.
This is useful for debugging with those files only created by build, such as when I make #27 