### PR TITLE
docs: fix an attribute name in the vue 2.5 doc

### DIFF
--- a/posts/vue-3-5.md
+++ b/posts/vue-3-5.md
@@ -46,7 +46,7 @@ const props = withDefaults(
 ```ts
 const { count = 0, msg = 'hello' } = defineProps<{
   count?: number
-  message?: string
+  msg?: string
 }>()
 ```
 


### PR DESCRIPTION
I was reading the documentation and I found this detail to be corrected so I created a PR to resolve it, there is no issue associated with this change.