### PR TITLE
fix (3.5): incorrect Teleport prop name

### DIFF
--- a/posts/vue-3-5.md
+++ b/posts/vue-3-5.md
@@ -178,7 +178,7 @@ A known constraint of the built-in `<Teleport>` component is that its target ele
 In 3.5, we have introduced a `defer` prop for `<Teleport>` which mounts it after the current render cycle, so this will now work:
 
 ```html
-<Teleport defer target="#container">...</Teleport>
+<Teleport defer to="#container">...</Teleport>
 <div id="container"></div>
 ```
 


### PR DESCRIPTION
Teleport target prop mentioned in the blog is actually `to` and not `target`